### PR TITLE
Remove dependency to fastlane

### DIFF
--- a/xcodegen.gemspec
+++ b/xcodegen.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'slop', '~> 4.0'
   spec.add_dependency 'paint', '~> 1.0.1'
   spec.add_dependency 'xcodeproj', '~> 1.4.1'
-  spec.add_dependency 'fastlane_core', '~> 0.57.1'
   spec.add_dependency 'listen', '~> 3.1.5'
   spec.add_dependency 'semantic', '~> 1.4.1'
   spec.add_dependency 'awesome_print', '~> 1.7.0'


### PR DESCRIPTION
With an upcoming _fastlane_ release it is important to remove the dependency to _fastlane_ and _fastlane_core_, see https://github.com/fastlane/fastlane/issues/7412 for more information